### PR TITLE
Fix buffer size too small

### DIFF
--- a/hyprpy/utils/sockets.py
+++ b/hyprpy/utils/sockets.py
@@ -147,7 +147,13 @@ class CommandSocket(AbstractSocket):
             try:
                 s.connect(str(self.path_to_socket))
                 s.sendall(message.encode('utf-8'))
-                return s.recv(4096).decode('utf-8')
+                bytes = bytearray()
+                while True:
+                    msg = s.recv(4096)
+                    if msg:
+                        bytes.extend(msg)
+                    else:
+                        return bytes.decode('utf-8')
             except TimeoutError as e:
                 log.error(f"Failed to send command: {command=!r} {flags=} {args=}")
                 raise SocketError(f"Socket timed out: {e}")


### PR DESCRIPTION
I'm getting a `JSONDecodeError` by opening many windows and running:

```
from hyprpy import Hyprland
windows = Hyprland().get_windows()
```

The cause is `s.recv` at https://github.com/ulinja/hyprpy/blob/main/hyprpy/utils/sockets.py#L150 is only reading 4096 bytes, when `hyprctl`'s output size can be much greater.

Fixed by reading from the socket in a loop until no more bytes are returned.