### PR TITLE
Fix failure to find Hyprland sockets on newer commits

### DIFF
--- a/hyprpy/components/instances.py
+++ b/hyprpy/components/instances.py
@@ -7,7 +7,6 @@ and offers capabilities to listen to events and signals emitted by the underlyin
 from typing import List, Union
 import json
 import logging
-import os.path
 
 from hyprpy.data.models import InstanceData
 from hyprpy.components.windows import Window
@@ -37,18 +36,10 @@ class Instance:
         #: `Instance signature <https://wiki.hyprland.org/IPC/#hyprland-instance-signature-his>`_ of the Hyprland instance.
         self.signature: str = data.signature
 
-        # find where the runtime directory of Hyprland is located
-        if os.path.exists( f'{os.environ["XDG_RUNTIME_DIR"]}/hypr' ):
-            path = f'{os.environ["XDG_RUNTIME_DIR"]}/hypr'
-        elif os.path.exists( '/tmp/hypr' ):
-            path = '/tmp/hypr'
-        else:
-            raise RuntimeError( 'Failed to find Hyprland runtime directory.' )
-
         #: The Hyprland event socket for this instance.
-        self.event_socket: EventSocket = EventSocket(signature, path)
+        self.event_socket: EventSocket = EventSocket(signature)
         #: The Hyprland command socket for this instance.
-        self.command_socket: CommandSocket = CommandSocket(signature, path)
+        self.command_socket: CommandSocket = CommandSocket(signature)
 
         #: Signal emitted when a new workspace gets created. Sends ``created_workspace_id``, the :attr:`~hyprpy.components.workspaces.Workspace.id` of the created workspace, as signal data.
         self.signal_workspace_created: Signal = Signal(self)

--- a/hyprpy/components/instances.py
+++ b/hyprpy/components/instances.py
@@ -7,6 +7,7 @@ and offers capabilities to listen to events and signals emitted by the underlyin
 from typing import List, Union
 import json
 import logging
+import os.path
 
 from hyprpy.data.models import InstanceData
 from hyprpy.components.windows import Window
@@ -36,10 +37,18 @@ class Instance:
         #: `Instance signature <https://wiki.hyprland.org/IPC/#hyprland-instance-signature-his>`_ of the Hyprland instance.
         self.signature: str = data.signature
 
+        # find where the runtime directory of Hyprland is located
+        if os.path.exists( f'{os.environ["XDG_RUNTIME_DIR"]}/hypr' ):
+            path = f'{os.environ["XDG_RUNTIME_DIR"]}/hypr'
+        elif os.path.exists( '/tmp/hypr' ):
+            path = '/tmp/hypr'
+        else:
+            raise RuntimeError( 'Failed to find Hyprland runtime directory.' )
+
         #: The Hyprland event socket for this instance.
-        self.event_socket: EventSocket = EventSocket(signature)
+        self.event_socket: EventSocket = EventSocket(signature, path)
         #: The Hyprland command socket for this instance.
-        self.command_socket: CommandSocket = CommandSocket(signature)
+        self.command_socket: CommandSocket = CommandSocket(signature, path)
 
         #: Signal emitted when a new workspace gets created. Sends ``created_workspace_id``, the :attr:`~hyprpy.components.workspaces.Workspace.id` of the created workspace, as signal data.
         self.signal_workspace_created: Signal = Signal(self)

--- a/hyprpy/utils/sockets.py
+++ b/hyprpy/utils/sockets.py
@@ -54,7 +54,7 @@ class AbstractSocket(ABC):
     Upon initialization, the underlying :class:`~socket.socket` object is *not* created.
     Users must explicitly call :meth:`~AbstractSocket.connect` prior
     to using the :class:`~socket.socket`, and should call :meth:`~AbstractSocket.close`
-    aftwerwards.
+    afterwards.
     """
 
     def __init__(self, signature: str):
@@ -174,9 +174,9 @@ class EventSocket(AbstractSocket):
     windows or workspaces being created or destroyed.
     """
 
-    def __init__(self, signature: str):
+    def __init__(self, signature: str, runtime_dir: str):
         super().__init__(signature)
-        self._path_to_socket = PosixPath(f"/tmp/hypr/{self._signature}/.socket2.sock")
+        self._path_to_socket = PosixPath(f"{runtime_dir}/{self._signature}/.socket2.sock")
         if not self._path_to_socket.is_socket():
             raise FileNotFoundError(f"No socket found at {self._path_to_socket!r}.")
 
@@ -188,9 +188,9 @@ class CommandSocket(AbstractSocket):
     a wide range of commands, as explained in `the Hyprland wiki <https://wiki.hyprland.org/Configuring/Using-hyprctl>`_.
     """
 
-    def __init__(self, signature: str):
+    def __init__(self, signature: str, runtime_dir: str):
         super().__init__(signature)
-        self._path_to_socket = PosixPath(f"/tmp/hypr/{self._signature}/.socket.sock")
+        self._path_to_socket = PosixPath(f"{runtime_dir}/{self._signature}/.socket.sock")
         if not self._path_to_socket.is_socket():
             raise FileNotFoundError(f"No socket found at {self._path_to_socket!r}.")
 

--- a/hyprpy/utils/sockets.py
+++ b/hyprpy/utils/sockets.py
@@ -185,7 +185,7 @@ class EventSocket(AbstractSocket):
         elif os.path.exists( f'{os.environ["XDG_RUNTIME_DIR"]}/hypr' ):
             path = f'{os.environ["XDG_RUNTIME_DIR"]}/hypr'
         else:
-            raise RuntimeError( "Directory `$XDG_RUNTIME_DIR/hypr` doesn't exist, was Hyprland started?." )
+            raise RuntimeError( "Directory `$XDG_RUNTIME_DIR/hypr` doesn't exist, was Hyprland started?" )
 
         self._path_to_socket = PosixPath(f"{path}/{self._signature}/.socket2.sock")
         if not self._path_to_socket.is_socket():
@@ -210,7 +210,7 @@ class CommandSocket(AbstractSocket):
         elif os.path.exists( f'{os.environ["XDG_RUNTIME_DIR"]}/hypr' ):
             path = f'{os.environ["XDG_RUNTIME_DIR"]}/hypr'
         else:
-            raise RuntimeError( "Directory `$XDG_RUNTIME_DIR/hypr` doesn't exist, was Hyprland started?." )
+            raise RuntimeError( "Directory `$XDG_RUNTIME_DIR/hypr` doesn't exist, was Hyprland started?" )
 
         self._path_to_socket = PosixPath(f"{path}/{self._signature}/.socket.sock")
         if not self._path_to_socket.is_socket():

--- a/hyprpy/utils/sockets.py
+++ b/hyprpy/utils/sockets.py
@@ -27,7 +27,7 @@ Examples:
     # Send a command
     instance.command_socket.send_command("dispatch", flags=["--single-instance"], args=["exec", "kitty"])
 """
-
+import os.path
 from abc import ABC
 from typing import List
 from pathlib import PosixPath
@@ -174,9 +174,20 @@ class EventSocket(AbstractSocket):
     windows or workspaces being created or destroyed.
     """
 
-    def __init__(self, signature: str, runtime_dir: str):
+    def __init__(self, signature: str):
         super().__init__(signature)
-        self._path_to_socket = PosixPath(f"{runtime_dir}/{self._signature}/.socket2.sock")
+
+        # find where the runtime directory of Hyprland is located
+        if os.path.exists( '/tmp/hypr' ):
+            path = '/tmp/hypr'
+        elif os.environ.get( 'XDG_RUNTIME_DIR', '' ) == '':
+            raise RuntimeError( 'Environment variable `XDG_RUNTIME_DIR` has not been set.' )
+        elif os.path.exists( f'{os.environ["XDG_RUNTIME_DIR"]}/hypr' ):
+            path = f'{os.environ["XDG_RUNTIME_DIR"]}/hypr'
+        else:
+            raise RuntimeError( "Directory `$XDG_RUNTIME_DIR/hypr` doesn't exist, was Hyprland started?." )
+
+        self._path_to_socket = PosixPath(f"{path}/{self._signature}/.socket2.sock")
         if not self._path_to_socket.is_socket():
             raise FileNotFoundError(f"No socket found at {self._path_to_socket!r}.")
 
@@ -188,9 +199,20 @@ class CommandSocket(AbstractSocket):
     a wide range of commands, as explained in `the Hyprland wiki <https://wiki.hyprland.org/Configuring/Using-hyprctl>`_.
     """
 
-    def __init__(self, signature: str, runtime_dir: str):
+    def __init__(self, signature: str):
         super().__init__(signature)
-        self._path_to_socket = PosixPath(f"{runtime_dir}/{self._signature}/.socket.sock")
+
+        # find where the runtime directory of Hyprland is located
+        if os.path.exists( '/tmp/hypr' ):
+            path = '/tmp/hypr'
+        elif os.environ.get( 'XDG_RUNTIME_DIR', '' ) == '':
+            raise RuntimeError( 'Environment variable `XDG_RUNTIME_DIR` has not been set.' )
+        elif os.path.exists( f'{os.environ["XDG_RUNTIME_DIR"]}/hypr' ):
+            path = f'{os.environ["XDG_RUNTIME_DIR"]}/hypr'
+        else:
+            raise RuntimeError( "Directory `$XDG_RUNTIME_DIR/hypr` doesn't exist, was Hyprland started?." )
+
+        self._path_to_socket = PosixPath(f"{path}/{self._signature}/.socket.sock")
         if not self._path_to_socket.is_socket():
             raise FileNotFoundError(f"No socket found at {self._path_to_socket!r}.")
 


### PR DESCRIPTION
This makes the caller of the `*Socket` constructor provide a directory in which the signature folder should be located; the `Instance` class, which is the main caller of those constructors, will beforehand find the folder, or raise a `RuntimeError` if not found, and then pass it to the sockets.


If there are any problems with my changes, I'll be happy to address them.

Fixes #15 