### PR TITLE
Add missing Hyprland events as signals

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -8,11 +8,10 @@ On NixOS, an attempt to create a venv locally and running `pip install -r requir
 some of the pulled in pip wheels will attempt to compile the `cffi` package.
 This requires the `libcffi` C library to be linked during the build, causing pip to fail on NixOS.
 
-To fix this, use the provided `shell.nix`, which will pull in the required library and make it available in the
-created venv. You have to delete your existing `.venv` folder if it is present:
+To fix this, use the provided `shell.nix`, which will pull in the required dependencies from nixpkgs rather
+than installing them using pip and `requirements.txt`:
 
 ```bash
-rm -rf .venv
 nix-shell
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 With Hyprpy you can very easily retrieve information about windows, workspaces and monitors
 in a running Hyprland instance.
-It also offers an event monitor, allowing you to write your own callback functions which
+It also offers an event monitor, allowing you to write your own python callback functions which
 execute in response to Hyprland events.
 
 Hyprpy uses unix sockets to communicate with Hyprland, making it **fast** and **efficient**.
@@ -77,12 +77,12 @@ if special_workspace:
 # Show a desktop notification every time we switch to workspace 6
 from hyprpy.utils.shell import run_or_fail
 
-def workspace_changed(sender, **kwargs):
-    current_workspace_id = kwargs.get('active_workspace_id')
-    if current_workspace_id == 6:
+def on_workspace_changed(sender, **kwargs):
+    workspace_id = kwargs.get('workspace_id')
+    if workspace_id == 6:
         run_or_fail(["notify-send", "We are on workspace 6."])
 
-instance.signal_active_workspace_changed.connect(workspace_changed)
+instance.signals.workspacev2.connect(on_workspace_changed)
 instance.watch()
 ```
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,7 @@ release = '0.1.0'
 add_module_names = False
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinxemoji.sphinxemoji',
 ]
 
 templates_path = ['_templates']

--- a/docs/source/hyprpy.api-reference.components.rst
+++ b/docs/source/hyprpy.api-reference.components.rst
@@ -41,6 +41,14 @@ Monitor
    :undoc-members:
    :show-inheritance:
 
+Instance Signals
+----------------
+
+.. automodule:: hyprpy.components.instancesignals
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Misc.
 -----
 

--- a/hyprpy/components/instances.py
+++ b/hyprpy/components/instances.py
@@ -43,18 +43,24 @@ class Instance:
         #: The Hyprland command socket for this instance.
         self.command_socket: CommandSocket = CommandSocket(signature)
 
-        #: Signal emitted when a new workspace gets created. Sends ``created_workspace_id``, the :attr:`~hyprpy.components.workspaces.Workspace.id` of the created workspace, as signal data.
+        #: Signal emitted when a new workspace gets created.
+        #: Sends ``created_workspace_id``, the :attr:`~hyprpy.components.workspaces.Workspace.id` of the created workspace, as signal data.
         self.signal_workspace_created: Signal = Signal(self)
-        #: Signal emitted when an existing workspace gets destroyed. Sends ``destroyed_workspace_id``, the :attr:`~hyprpy.components.workspaces.Workspace.id` of the destroyed workspace, as signal data
+        #: Signal emitted when an existing workspace gets destroyed.
+        #: Sends ``destroyed_workspace_id``, the :attr:`~hyprpy.components.workspaces.Workspace.id` of the destroyed workspace, as signal data
         self.signal_workspace_destroyed: Signal = Signal(self)
-        #: Signal emitted when the focus changes to another workspace. Sends ``active_workspace_id``, the :attr:`~hyprpy.components.workspaces.Workspace.id` of the now active workspace, as signal data.
+        #: Signal emitted when the focus changes to another workspace.
+        #: Sends ``active_workspace_id``, the :attr:`~hyprpy.components.workspaces.Workspace.id` of the now active workspace, as signal data.
         self.signal_active_workspace_changed: Signal = Signal(self)
 
-        #: Signal emitted when a new window gets created. Sends ``created_window_address``, the :attr:`~hyprpy.components.windows.Window.address` of the newly created window, as signal data.
+        #: Signal emitted when a new window gets created.
+        #: Sends ``created_window_address``, the :attr:`~hyprpy.components.windows.Window.address` of the newly created window, as signal data.
         self.signal_window_created: Signal = Signal(self)
-        #: Signal emitted when an existing window gets destroyed. Sends ``destroyed_window_address``, the :attr:`~hyprpy.components.windows.Window.address` of the destroyed window, as signal data.
+        #: Signal emitted when an existing window gets destroyed.
+        #: Sends ``destroyed_window_address``, the :attr:`~hyprpy.components.windows.Window.address` of the destroyed window, as signal data.
         self.signal_window_destroyed: Signal = Signal(self)
-        #: Signal emitted when the focus changes to another window. Sends ``active_window_address``, the :attr:`~hyprpy.components.windows.Window.address` of the now active window, as signal data.
+        #: Signal emitted when the focus changes to another window.
+        #: Sends ``active_window_address``, the :attr:`~hyprpy.components.windows.Window.address` of the now active window, as signal data.
         self.signal_active_window_changed: Signal = Signal(self)
 
 

--- a/hyprpy/components/instancesignals.py
+++ b/hyprpy/components/instancesignals.py
@@ -1,0 +1,814 @@
+"""The list of signals emitted by hyprpy, which covers all `events sent by Hyprland <https://wiki.hyprland.org/IPC/#events-list>`_."""
+import logging
+
+from hyprpy.utils.signals import Signal
+
+
+log = logging.getLogger(__name__)
+
+
+class InstanceSignalCollection:
+    """The collection of Hyprland signals emitted by an :attr:`~hyprpy.components.instances.Instance`."""
+
+    def __init__(self):
+        #: Emits the following Signal Data when a keyboard's layout is changed:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================= ============ ===============================
+        #:       Name              Type         Description
+        #:       ================= ============ ===============================
+        #:       ``keyboard_name`` :class:`str` Name of the keyboard
+        #:       ``layout_name``   :class:`str` Name of the newly active layout
+        #:       ================= ============ ===============================
+        self.activelayout: Signal = Signal(self)
+
+        #: Emits the following Signal Data when the special workspace on a monitor changes:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ======================== ====================================================================================================================================================================
+        #:       Name               Type                     Description
+        #:       ================== ======================== ====================================================================================================================================================================
+        #:       ``workspace_name`` :class:`str` or ``None`` :attr:`~hyprpy.components.workspaces.Workspace.name` of the workspace (``"special:special"``) if the special workspace was created, and ``None`` if it was destroyed
+        #:       ``monitor_name``   :class:`str`             :attr:`~hyprpy.components.monitors.Monitor.name` of the monitor
+        #:       ================== ======================== ====================================================================================================================================================================
+        #:
+        self.activespecial: Signal = Signal(self)
+
+        #: Emits the following Signal Data when the special workspace on a monitor changes:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ======================== ====================================================================================================================================================================
+        #:       Name               Type                     Description
+        #:       ================== ======================== ====================================================================================================================================================================
+        #:       ``workspace_id``   :class:`int` or ``None`` :attr:`~hyprpy.components.workspaces.Workspace.id` of the workspace (``-99``) if the special workspace was created, and ``None`` if it was destroyed
+        #:       ``workspace_name`` :class:`str` or ``None`` :attr:`~hyprpy.components.workspaces.Workspace.name` of the workspace (``"special:special"``) if the special workspace was created, and ``None`` if it was destroyed
+        #:       ``monitor_name``   :class:`str`             :attr:`~hyprpy.components.monitors.Monitor.name` of the monitor
+        #:       ================== ======================== ====================================================================================================================================================================
+        #:
+        self.activespecialv2: Signal = Signal(self)
+
+        #: Emits the following Signal Data when the active window is changed:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================ ============ =================================================================================
+        #:       Name             Type         Description
+        #:       ================ ============ =================================================================================
+        #:       ``window_class`` :class:`str` The newly active window's :attr:`~hyprpy.components.windows.Window.wm_class`
+        #:       ``window_title`` :class:`str` Name of the newly active window's :attr:`~hyprpy.components.windows.Window.title`
+        #:       ================ ============ =================================================================================
+        self.activewindow: Signal = Signal(self)
+
+        #: Emits the following Signal Data when the active window is changed:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ ===========================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ ===========================================================================
+        #:       ``window_address`` :class:`str` The newly active Window's :attr:`~hyprpy.components.windows.Window.address`
+        #:       ================== ============ ===========================================================================
+        self.activewindowv2: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a window's floating state changes:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============= ===============================================================
+        #:       Name               Type          Description
+        #:       ================== ============= ===============================================================
+        #:       ``window_address`` :class:`str`  :attr:`~hyprpy.components.windows.Window.address` of the window
+        #:       ``is_floating``    :class:`bool` ``True`` if the window is floating, and ``False`` otherwise
+        #:       ================== ============= ===============================================================
+        self.changefloatingmode: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a layerSurface is unmapped:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ============= ============ ===========
+        #:       Name          Type         Description
+        #:       ============= ============ ===========
+        #:       ``namespace`` :class:`str` Unknown.
+        #:       ============= ============ ===========
+        self.closelayer: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a window is closed:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ ======================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ ======================================================================
+        #:       ``window_address`` :class:`str` :attr:`~hyprpy.components.windows.Window.address` of the closed window
+        #:       ================== ============ ======================================================================
+        self.closewindow: Signal = Signal(self)
+
+        #: Emitted upon a completed config reload.
+        #:
+        #: Does not emit any Signal Data.
+        self.configreloaded: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a workspace is created:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ =============================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ =============================================================================
+        #:       ``workspace_name`` :class:`str` :attr:`~hyprpy.components.workspaces.Workspace.name` of the created workspace
+        #:       ================== ============ =============================================================================
+        self.createworkspace: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a workspace is created:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ =============================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ =============================================================================
+        #:       ``workspace_id``   :class:`int` :attr:`~hyprpy.components.workspaces.Workspace.id` of the created workspace
+        #:       ``workspace_name`` :class:`str` :attr:`~hyprpy.components.workspaces.Workspace.name` of the created workspace
+        #:       ================== ============ =============================================================================
+        self.createworkspacev2: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a workspace is destroyed:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ ===============================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ ===============================================================================
+        #:       ``workspace_name`` :class:`str` :attr:`~hyprpy.components.workspaces.Workspace.name` of the destroyed workspace
+        #:       ================== ============ ===============================================================================
+        self.destroyworkspace: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a workspace is destroyed:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ ===============================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ ===============================================================================
+        #:       ``workspace_id``   :class:`int` :attr:`~hyprpy.components.workspaces.Workspace.id` of the destroyed workspace
+        #:       ``workspace_name`` :class:`str` :attr:`~hyprpy.components.workspaces.Workspace.name` of the destroyed workspace
+        #:       ================== ============ ===============================================================================
+        self.destroyworkspacev2: Signal = Signal(self)
+
+        #: Emits the following Signal Data when the active monitor changes:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ ==================================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ ==================================================================================
+        #:       ``monitor_name``   :class:`str` :attr:`~hyprpy.components.monitors.Monitor.name` of the newly active monitor
+        #:       ``workspace_name`` :class:`str` :attr:`~hyprpy.components.workspaces.Workspace.name` of the newly active workspace
+        #:       ================== ============ ==================================================================================
+        self.focusedmon: Signal = Signal(self)
+
+        #: Emits the following Signal Data when the active monitor changes:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ =======================================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ =======================================================================================
+        #:       ``monitor_name``   :class:`str` :attr:`~hyprpy.components.monitors.Monitor.name` of the newly active monitor
+        #:       ``workspace_id``   :class:`int` :attr:`~hyprpy.components.workspaces.Workspace.id` of the workspace which is now active
+        #:       ================== ============ =======================================================================================
+        self.focusedmonv2: Signal = Signal(self)
+
+        #: Emits the following Signal Data when the fullscreen state of any window changes:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================= ============= ===========================================================================================
+        #:       Name              Type          Description
+        #:       ================= ============= ===========================================================================================
+        #:       ``is_fullscreen`` :class:`bool` ``True`` if fullscreen mode was activated, and ``False`` if fullscreen mode was deactivated
+        #:       ================= ============= ===========================================================================================
+        self.fullscreen: Signal = Signal(self)
+
+        #: Emits the following Signal Data when ``ignoregrouplock`` is toggled:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ============================= ============= ==================================================================================
+        #:       Name                          Type          Description
+        #:       ============================= ============= ==================================================================================
+        #:       ``ignore_group_lock_enabled`` :class:`bool` ``True`` if ``ignoregrouplock`` was activated, and ``False`` if it was deactivated
+        #:       ============================= ============= ==================================================================================
+        self.ignoregrouplock: Signal = Signal(self)
+
+        #: Emits the following Signal Data when ``lockgroups`` is toggled:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ======================= ============= =============================================================================
+        #:       Name                    Type          Description
+        #:       ======================= ============= =============================================================================
+        #:       ``lock_groups_enabled`` :class:`bool` ``True`` if ``lockgroups`` was activated, and ``False`` if it was deactivated
+        #:       ======================= ============= =============================================================================
+        self.lockgroups: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a monitor is added:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================ ============ ============================================================================
+        #:       Name              Type        Description
+        #:       ================ ============ ============================================================================
+        #:       ``monitor_name`` :class:`str`  :attr:`~hyprpy.components.monitors.Monitor.name` of the newly added monitor
+        #:       ================ ============ ============================================================================
+        self.monitoradded: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a monitor is added:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ======================= ============ ==================================================================================
+        #:       Name                    Type         Description
+        #:       ======================= ============ ==================================================================================
+        #:       ``monitor_id``          :class:`int` :attr:`~hyprpy.components.monitors.Monitor.id` of the newly added monitor
+        #:       ``monitor_name``        :class:`str` :attr:`~hyprpy.components.monitors.Monitor.name` of the newly added monitor
+        #:       ``monitor_description`` :class:`str` :attr:`~hyprpy.components.monitors.Monitor.description` of the newly added monitor
+        #:       ======================= ============ ==================================================================================
+        self.monitoraddedv2: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a monitor is removed:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================ ============ ========================================================================
+        #:       Name              Type        Description
+        #:       ================ ============ ========================================================================
+        #:       ``monitor_name`` :class:`str`  :attr:`~hyprpy.components.monitors.Monitor.name` of the removed monitor
+        #:       ================ ============ ========================================================================
+        self.monitorremoved: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a window is merged into a group:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ ======================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ ======================================================================
+        #:       ``window_address`` :class:`str` :attr:`~hyprpy.components.windows.Window.address` of the merged window
+        #:       ================== ============ ======================================================================
+        self.moveintogroup: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a window is removed from a group:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ =======================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ =======================================================================
+        #:       ``window_address`` :class:`str` :attr:`~hyprpy.components.windows.Window.address` of the removed window
+        #:       ================== ============ =======================================================================
+        self.moveoutofgroup: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a window is moved to a workspace:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ =============================================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ =============================================================================================
+        #:       ``window_address`` :class:`str` :attr:`~hyprpy.components.windows.Window.address` of the window which was moved
+        #:       ``workspace_name`` :class:`str` :attr:`~hyprpy.components.workspaces.Workspace.name` of the workspace the window was moved to
+        #:       ================== ============ =============================================================================================
+        self.movewindow: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a window is moved to a workspace:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ =============================================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ =============================================================================================
+        #:       ``window_address`` :class:`str` :attr:`~hyprpy.components.windows.Window.address` of the window which was moved
+        #:       ``workspace_name`` :class:`str` :attr:`~hyprpy.components.workspaces.Workspace.name` of the workspace the window was moved to
+        #:       ``workspace_id``   :class:`int` :attr:`~hyprpy.components.workspaces.Workspace.id` of the workspace the window was moved to
+        #:       ================== ============ =============================================================================================
+        self.movewindowv2: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a workspace is moved to a different monitor:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ =================================================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ =================================================================================================
+        #:       ``workspace_name`` :class:`str` :attr:`~hyprpy.components.workspaces.Workspace.name` of the workspace which was moved
+        #:       ``monitor_name``   :class:`str` :attr:`~hyprpy.components.monitors.Monitor.name` of the monitor which the workspace was moved to
+        #:       ================== ============ =================================================================================================
+        self.moveworkspace: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a workspace is moved to a different monitor:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ =================================================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ =================================================================================================
+        #:       ``workspace_id``   :class:`int` :attr:`~hyprpy.components.workspaces.Workspace.id` of the workspace which was moved
+        #:       ``workspace_name`` :class:`str` :attr:`~hyprpy.components.workspaces.Workspace.name` of the workspace which was moved
+        #:       ``monitor_name``   :class:`str` :attr:`~hyprpy.components.monitors.Monitor.name` of the monitor which the workspace was moved to
+        #:       ================== ============ =================================================================================================
+        self.moveworkspacev2: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a layerSurface is mapped:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ ===========
+        #:       Name               Type         Description
+        #:       ================== ============ ===========
+        #:       ``namespace``      :class:`str` Unknown.
+        #:       ================== ============ ===========
+        self.openlayer: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a window is opened:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ ====================================================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ ====================================================================================================
+        #:       ``window_address`` :class:`str` :attr:`~hyprpy.components.windows.Window.address` of the opened window
+        #:       ``workspace_name`` :class:`str` :attr:`~hyprpy.components.workspaces.Workspace.name` of the workspace on which the window was opened
+        #:       ``window_class``   :class:`str` The opened window's :attr:`~hyprpy.components.windows.Window.wm_class`
+        #:       ``window_title``   :class:`str` Name of the opened window's :attr:`~hyprpy.components.windows.Window.title`
+        #:       ================== ============ ====================================================================================================
+        self.openwindow: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a window is pinned or unpinned:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============= ===============================================================================
+        #:       Name               Type          Description
+        #:       ================== ============= ===============================================================================
+        #:       ``window_address`` :class:`str`  :attr:`~hyprpy.components.windows.Window.address` of the pinned/unpinned window
+        #:       ``is_pinned``      :class:`bool` ``True`` if the window was pinned, and ``False`` if it was unpinned.
+        #:       ================== ============= ===============================================================================
+        self.pin: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a workspace is renamed:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ =====================================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ =====================================================================================
+        #:       ``workspace_id``   :class:`int` :attr:`~hyprpy.components.workspaces.Workspace.id` of the workspace which was renamed
+        #:       ``new_name``       :class:`str` New :attr:`~hyprpy.components.workspaces.Workspace.name` of the workspace
+        #:       ================== ============ =====================================================================================
+        self.renameworkspace: Signal = Signal(self)
+
+        #: Emits the following Signal Data when the screencopy state of a client changes:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ====================== ============= ==========================================================================================================
+        #:       Name                   Type          Description
+        #:       ====================== ============= ==========================================================================================================
+        #:       ``screencast_enabled`` :class:`bool` ``True`` if the screencast was enabled, and ``False`` if it was disabled
+        #:       ``screencast_type``    :class:`str`  ``"MONITOR"`` if the screencast was enabled for a monitor, and ``"WINDOW"`` if it was enabled for a window
+        #:       ====================== ============= ==========================================================================================================
+        self.screencast: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a keybind submap changes:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       =============== ======================== =======================================================================
+        #:       Name            Type                     Description
+        #:       =============== ======================== =======================================================================
+        #:       ``submap_name`` :class:`str` or ``None`` Name of the new submap, or ``None`` if the default submap is now active
+        #:       =============== ======================== =======================================================================
+        self.submap: Signal = Signal(self)
+
+        #: Emits the following Signal Data when the togglegroup command is used:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ==================== ============= ===================================================================================================
+        #:       Name                 Type          Description
+        #:       ==================== ============= ===================================================================================================
+        #:       ``group_is_active``  :class:`bool` ``True`` if the group was created, and ``False`` if it was destroyed
+        #:       ``window_addresses`` ``list[str]`` :class:`list` of :attr:`~hyprpy.components.windows.Window.address`\ es of the windows in the group
+        #:       ==================== ============= ===================================================================================================
+        self.togglegroup: Signal = Signal(self)
+
+        #: Emits the following Signal Data when a window requests an urgent state:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============= =======================================================================================
+        #:       Name               Type          Description
+        #:       ================== ============= =======================================================================================
+        #:       ``window_address`` :class:`str`  :attr:`~hyprpy.components.windows.Window.address` of the window requesting urgent state
+        #:       ================== ============= =======================================================================================
+        self.urgent: Signal = Signal(self)
+
+        #: Emits the following Signal Data when the title of a window changes:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============= ===================================================================================
+        #:       Name               Type          Description
+        #:       ================== ============= ===================================================================================
+        #:       ``window_address`` :class:`str`  :attr:`~hyprpy.components.windows.Window.address` of the window whose title changed
+        #:       ================== ============= ===================================================================================
+        self.windowtitle: Signal = Signal(self)
+
+        #: Emits the following Signal Data when the title of a window changes:
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============= ===================================================================================
+        #:       Name               Type          Description
+        #:       ================== ============= ===================================================================================
+        #:       ``window_address`` :class:`str`  :attr:`~hyprpy.components.windows.Window.address` of the window whose title changed
+        #:       ``window_title``   :class:`str`  :attr:`~hyprpy.components.windows.Window.title` of the window whose title changed
+        #:       ================== ============= ===================================================================================
+        self.windowtitlev2: Signal = Signal(self)
+
+        #: Emits the following Signal Data when the active workspace changes (ignores mouse movements):
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ ==================================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ ==================================================================================
+        #:       ``workspace_name`` :class:`str` :attr:`~hyprpy.components.workspaces.Workspace.name` of the newly active workspace
+        #:       ================== ============ ==================================================================================
+        self.workspace: Signal = Signal(self)
+
+        #: Emits the following Signal Data when the active workspace changes (ignores mouse movements):
+        #:
+        #:    .. table::
+        #:       :widths: auto
+        #:       :align: left
+        #:
+        #:       ================== ============ ==================================================================================
+        #:       Name               Type         Description
+        #:       ================== ============ ==================================================================================
+        #:       ``workspace_name`` :class:`str` :attr:`~hyprpy.components.workspaces.Workspace.name` of the newly active workspace
+        #:       ``workspace_id``   :class:`int` :attr:`~hyprpy.components.workspaces.Workspace.id` of the newly active workspace
+        #:       ================== ============ ==================================================================================
+        self.workspacev2: Signal = Signal(self)
+
+    def _handle_socket_data(self, data: str) -> None:
+        """Parses a line of IPC socket data to fire the appropriate Signal.
+
+        Identifies the signal to emit, then parses the event data and emits the signal.
+        """
+        event_name, event_data = data.split('>>', maxsplit=1)
+
+        try:
+            signal: Signal = getattr(self, event_name)
+        except AttributeError:
+            log.error(f"Failed to resolve signal: unrecognized IPC event '{event_name}'")
+            return
+        try:
+            signal_data_parser = getattr(self, f"_parse_{event_name}")
+        except AttributeError:
+            log.error(f"Failed to resolve signal parser: unrecognized IPC event '{event_name}'")
+            return
+
+        # If the signal has no observers, do nothing
+        if not signal._observers:
+            return
+
+        try:
+            signal_data: dict = signal_data_parser(event_data)
+        except Exception as e:
+            log.error(f"{type(e).__name__} while parsing signal data for '{event_name}': {e}")
+            return
+
+        signal.emit(**signal_data)
+
+    def _parse_activelayout(self, data: str) -> dict:
+        keyboard_name, layout_name = data.split(",", maxsplit=1)
+        return {
+            "keyboard_name": keyboard_name,
+            "layout_name": layout_name,
+        }
+
+    def _parse_activespecial(self, data: str) -> dict:
+        workspace_name, monitor_name = data.split(",", maxsplit=1)
+        return {
+            "workspace_name": workspace_name or None,
+            "monitor_name": monitor_name,
+        }
+
+    def _parse_activespecialv2(self, data: str) -> dict:
+        workspace_id, workspace_name, monitor_name = data.split(",", maxsplit=2)
+        return {
+            "workspace_id": int(workspace_id) if workspace_id else None,
+            "workspace_name": workspace_name or None,
+            "monitor_name": monitor_name,
+        }
+
+    def _parse_activewindow(self, data: str) -> dict:
+        window_class, window_title = data.split(",", maxsplit=1)
+        return {
+            "window_class": window_class,
+            "window_title": window_title,
+        }
+
+    def _parse_activewindowv2(self, data: str) -> dict:
+        return {
+            "window_address": data,
+        }
+
+    def _parse_changefloatingmode(self, data: str) -> dict:
+        window_address, is_floating = data.split(",")
+        return {
+            "window_address": window_address,
+            "is_floating": bool(int(is_floating)),
+        }
+
+    def _parse_closelayer(self, data: str) -> dict:
+        return {
+            "namespace": data,
+        }
+
+    def _parse_closewindow(self, data: str) -> dict:
+        return {
+            "window_address": data,
+        }
+
+    def _parse_configreloaded(self, data: str) -> dict:
+        return {}
+
+    def _parse_createworkspace(self, data: str) -> dict:
+        return {
+            "workspace_name": data,
+        }
+
+    def _parse_createworkspacev2(self, data: str) -> dict:
+        workspace_id, workspace_name = data.split(",", maxsplit=1)
+        return {
+            "workspace_id": int(workspace_id),
+            "workspace_name": workspace_name,
+        }
+
+    def _parse_destroyworkspace(self, data: str) -> dict:
+        return {
+            "workspace_name": data,
+        }
+
+    def _parse_destroyworkspacev2(self, data: str) -> dict:
+        workspace_id, workspace_name = data.split(",", maxsplit=1)
+        return {
+            "workspace_id": int(workspace_id),
+            "workspace_name": workspace_name,
+        }
+
+    def _parse_focusedmon(self, data: str) -> dict:
+        monitor_name, workspace_name = data.split(",", maxsplit=1)
+        return {
+            "monitor_name": monitor_name,
+            "workspace_name": workspace_name,
+        }
+
+    def _parse_focusedmonv2(self, data: str) -> dict:
+        monitor_name, workspace_id = data.rsplit(",", maxsplit=1)
+        return {
+            "monitor_name": monitor_name,
+            "workspace_id": int(workspace_id),
+        }
+
+    def _parse_fullscreen(self, data: str) -> dict:
+        return {
+            "is_fullscreen": bool(int(data)),
+        }
+
+    def _parse_ignoregrouplock(self, data: str) -> dict:
+        return {
+            "ignore_group_lock_enabled": bool(int(data)),
+        }
+
+    def _parse_lockgroups(self, data: str) -> dict:
+        return {
+            "lock_groups_enabled": bool(int(data)),
+        }
+
+    def _parse_monitoradded(self, data: str) -> dict:
+        return {
+            "monitor_name": data,
+        }
+
+    def _parse_monitoraddedv2(self, data: str) -> dict:
+        monitor_id, monitor_name, monitor_description = data.split(",", maxsplit=2)
+        return {
+            "monitor_id": int(monitor_id),
+            "monitor_name": monitor_name,
+            "monitor_description": monitor_description,
+        }
+
+    def _parse_monitorremoved(self, data: str) -> dict:
+        return {
+            "monitor_name": data,
+        }
+
+    def _parse_moveintogroup(self, data: str) -> dict:
+        return {
+            "window_address": data,
+        }
+
+    def _parse_moveoutofgroup(self, data: str) -> dict:
+        return {
+            "window_address": data,
+        }
+
+    def _parse_movewindow(self, data: str) -> dict:
+        window_address, workspace_name = data.split(",", maxsplit=1)
+        return {
+            "window_address": window_address,
+            "workspace_name": workspace_name,
+        }
+
+    def _parse_movewindowv2(self, data: str) -> dict:
+        window_address, _other = data.split(",", maxsplit=1)
+        workspace_name, workspace_id = _other.rsplit(",", maxsplit=1)
+        return {
+            "window_address": window_address,
+            "workspace_name": workspace_name,
+            "workspace_id": int(workspace_id),
+        }
+
+    def _parse_moveworkspace(self, data: str) -> dict:
+        workspace_name, monitor_name = data.rsplit(",", maxsplit=1)
+        return {
+            "workspace_name": workspace_name,
+            "monitor_name": monitor_name,
+        }
+
+    def _parse_moveworkspacev2(self, data: str) -> dict:
+        workspace_id, _other = data.split(",", maxsplit=1)
+        workspace_name, monitor_name = _other.rsplit(",", maxsplit=1)
+        return {
+            "workspace_id": int(workspace_id),
+            "workspace_name": workspace_name,
+            "monitor_name": monitor_name,
+        }
+
+    def _parse_openlayer(self, data: str) -> dict:
+        return {
+            "namespace": data,
+        }
+
+    def _parse_openwindow(self, data: str) -> dict:
+        window_address, workspace_name, window_class, window_title = data.split(",", maxsplit=3)
+        return {
+            "window_address": window_address,
+            "workspace_name": workspace_name,
+            "window_class": window_class,
+            "window_title": window_title,
+        }
+
+    def _parse_pin(self, data: str) -> dict:
+        window_address, is_pinned = data.split(",")
+        return {
+            "window_address": window_address,
+            "is_pinned": bool(int(is_pinned)),
+        }
+
+    def _parse_renameworkspace(self, data: str) -> dict:
+        workspace_id, new_name = data.split(",", maxsplit=1)
+        return {
+            "workspace_id": int(workspace_id),
+            "new_name": new_name,
+        }
+
+    def _parse_screencast(self, data: str) -> dict:
+        screencast_enabled, _screencast_type_numeric = data.split(",")
+        screencast_type = "MONITOR" if int(_screencast_type_numeric) == 0 else "WINDOW"
+        return {
+            "screencast_enabled": bool(int(screencast_enabled)),
+            "screencast_type": screencast_type,
+        }
+
+    def _parse_submap(self, data: str) -> dict:
+        return {
+            "submap_name": data or None,
+        }
+
+    def _parse_togglegroup(self, data: str) -> dict:
+        group_is_active, window_addresses = data.split(",", maxsplit=1)
+        return {
+            "group_is_active": bool(int(group_is_active)),
+            "window_addresses": window_addresses.split(","),
+        }
+
+    def _parse_urgent(self, data: str) -> dict:
+        return {
+            "window_address": data,
+        }
+
+    def _parse_windowtitle(self, data: str) -> dict:
+        return {
+            "window_address": data,
+        }
+
+    def _parse_windowtitlev2(self, data: str) -> dict:
+        window_address, window_title = data.split(",", maxsplit=1)
+        return {
+            "window_address": window_address,
+            "window_title": window_title,
+        }
+
+    def _parse_workspace(self, data: str) -> dict:
+        return {
+            "workspace_name": data,
+        }
+
+    def _parse_workspacev2(self, data: str) -> dict:
+        workspace_name, workspace_id = data.rsplit(",", maxsplit=1)
+        return {
+            "workspace_name": workspace_name,
+            "workspace_id": int(workspace_id),
+        }

--- a/hyprpy/utils/signals.py
+++ b/hyprpy/utils/signals.py
@@ -30,8 +30,12 @@ Example:
 """
 
 from typing import Callable, List
+import logging
 
 from hyprpy.utils import assertions
+
+
+log = logging.getLogger(__name__)
 
 
 class Signal():
@@ -136,3 +140,34 @@ class Signal():
 
         for callback in self._observers:
             callback(self._sender, **kwargs)
+
+
+class DeprecatedSignal(Signal):
+    """Behaves just like a normal :class:`~hyprpy.utils.signals.Signal`, but logs deprecation warnings to the console.
+
+    A warning message is printed to the log whenever this Signal's methods are invoked.
+
+    :param sender: The source object sending the signal.
+    :type sender: :class:`object`
+    :param message: The warning message to log when this Signal gets used. This should be an informative deprecation warning.
+    :type message: :class:`str`
+    """
+
+    def __init__(self, sender: object, message: str):
+        super().__init__(sender)
+        self.message = message
+        log.warning(self.message)
+
+
+    def connect(self, callback: Callable) -> None:
+        super().connect(callback)
+        log.warning(self.message)
+
+
+    def disconnect(self, callback: Callable) -> None:
+        super().disconnect(callback)
+        log.warning(self.message)
+
+    def emit(self, **kwargs) -> None:
+        super().emit(**kwargs)
+        log.warning(self.message)

--- a/hyprpy/utils/signals.py
+++ b/hyprpy/utils/signals.py
@@ -46,6 +46,7 @@ class Signal():
     the signal's constructor.
 
     :param sender: The source object sending the signal.
+    :type sender: :class:`object`
 
     Example:
 
@@ -63,7 +64,7 @@ class Signal():
 
     def __init__(self, sender: object):
         self._observers: List[Callable] = []
-        self._sender = sender
+        self._sender: object = sender
 
 
     def connect(self, callback: Callable) -> None:
@@ -73,6 +74,7 @@ class Signal():
         followed by ``**kwargs``.
 
         :param callback: The callback function to be connected to this signal.
+        :type callback: :class:`Callable`
         :raises: :class:`TypeError` if ``callback`` is not callable.
         :raises: :class:`ValueError` if the first positional argument of ``callback`` is not ``sender``.
         :raises: :class:`ValueError` if ``callback`` does not accept keyword arguments.
@@ -99,6 +101,7 @@ class Signal():
         This is useful if you want to limit how often a callback should be executed.
 
         :param callback: The callback function to be disconnected.
+        :type callback: :class:`Callable`
         :raises: :class:`ValueError` if the specified callback is not in the list of observers.
 
         Example:
@@ -125,6 +128,7 @@ class Signal():
         this method.
 
         :param \\**kwargs: Keyword arguments that will be passed to each callback.
+        :type \\**kwargs: :class:`dict[str, any]`
 
         Example:
 

--- a/hyprpy/utils/signals.py
+++ b/hyprpy/utils/signals.py
@@ -62,6 +62,7 @@ class Signal():
         obj = MyClass()
     """
 
+
     def __init__(self, sender: object):
         self._observers: List[Callable] = []
         self._sender: object = sender
@@ -147,31 +148,38 @@ class Signal():
 
 
 class DeprecatedSignal(Signal):
-    """Behaves just like a normal :class:`~hyprpy.utils.signals.Signal`, but logs deprecation warnings to the console.
+    """Behaves just like a normal :class:`~hyprpy.utils.signals.Signal`, but logs a deprecation warning to the console.
 
-    A warning message is printed to the log whenever this Signal's methods are invoked.
+    A warning message is printed to the log when this Signal is connected to a callback.
 
     :param sender: The source object sending the signal.
     :type sender: :class:`object`
-    :param message: The warning message to log when this Signal gets used. This should be an informative deprecation warning.
-    :type message: :class:`str`
+    :param deprecated_signal_name: The name of the deprecated signal.
+    :type deprecated_signal_name: :class:`str`
+    :param replacement_signal_name: The name of the new signal, if applicable, to use in favour of the deprecated one.
+    :type replacement_signal_name: :class:`str`, optional
+
+    Example:
+
+    .. code-block:: python
+
+        signal = DeprecatedSignal("Instance.signal_workspace_created", "Instance.signals.workspace")
     """
 
-    def __init__(self, sender: object, message: str):
+    def __init__(self, sender: object, deprecated_signal_name: str, replacement_signal_name: str | None):
         super().__init__(sender)
-        self.message = message
-        log.warning(self.message)
-
+        self._warning_message = (
+            f"The '{deprecated_signal_name}' Signal is deprecated and will be removed in future versions of hyprpy."
+        )
+        if replacement_signal_name:
+            self._warning_message += f" You should use '{replacement_signal_name}' instead."
 
     def connect(self, callback: Callable) -> None:
         super().connect(callback)
-        log.warning(self.message)
-
+        log.warning(self._warning_message)
 
     def disconnect(self, callback: Callable) -> None:
         super().disconnect(callback)
-        log.warning(self.message)
 
     def emit(self, **kwargs) -> None:
         super().emit(**kwargs)
-        log.warning(self.message)

--- a/shell.nix
+++ b/shell.nix
@@ -1,25 +1,21 @@
 with import <nixpkgs> {};
-let
-  pythonPackages = python3Packages;
-in pkgs.mkShell rec {
-  name = "impurePythonEnv";
-  venvDir = "./.venv";
-  buildInputs = [
-    pythonPackages.python
-    pythonPackages.venvShellHook
-
-    # Add pip build-time dependencies
-    libffi
+pkgs.mkShell {
+  packages = with pkgs; [
+    (python3.withPackages(p: with p; [
+      pydantic
+      sphinx
+      sphinxemoji
+      (
+        buildPythonPackage rec {
+          pname = "sphinx_press_theme";
+          version = "0.9.1";
+          src = fetchPypi {
+            inherit pname version;
+            sha256 = "sha256-FkPe5zZfeDHR05cbOJt8JVZBp6ztdfBoH3FXTjgARs8=";
+          };
+          doCheck = false;
+        }
+      )
+    ]))
   ];
-
-  # Auto-run pip install if .venv does not exist
-  postVenvCreation = ''
-    unset SOURCE_DATE_EPOCH
-    pip install -r requirements.txt
-  '';
-
-  postShellHook = ''
-    # allow pip to install wheels
-    unset SOURCE_DATE_EPOCH
-  '';
 }


### PR DESCRIPTION
Resolves #17 by adding all Hyprland events not previously handled by hyprpy and by revamping the way signals are accessed on the `Instance` object.