### PR TITLE
Fix typing for `name` argument of `get_workspace_by_name`

### DIFF
--- a/hyprpy/components/instances.py
+++ b/hyprpy/components/instances.py
@@ -213,7 +213,7 @@ class Instance:
         workspace_data = json.loads(self.command_socket.send_command('activeworkspace', flags=['-j']))
         return Workspace(workspace_data, self)
 
-    def get_workspace_by_name(self, name: int) -> Union['Workspace', None]:
+    def get_workspace_by_name(self, name: str) -> Union['Workspace', None]:
         """Retrieves the :class:`~hyprpy.components.workspaces.Workspace` with the specified ``name``.
 
         :return: The :class:`~hyprpy.components.workspaces.Workspace` if it exists, or ``None`` otherwise.


### PR DESCRIPTION
Very small fix, the type for `get_workspace_by_name`'s `name` was `int` in the signature, but the body asserts that it is a string. Saw a pyright error and was confused, this makes the reported type reflect the assertion made by the function.